### PR TITLE
Properly handle the granularity flag in the segment descriptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbgeng"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Axel '0vercl0k' Souchet"]
 categories = ["api-bindings"]


### PR DESCRIPTION
This fixes https://github.com/0vercl0k/snapshot/issues/8