### PR TITLE
Synthetic module support

### DIFF
--- a/.github/workflows/dbgeng-rs.yml
+++ b/.github/workflows/dbgeng-rs.yml
@@ -36,7 +36,7 @@ jobs:
 
   doc:
     name: doc
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1", features = ["derive"], optional = true }
-bitflags = "2.4.2"
-anyhow = { version = "1.0.79" }
-windows = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_Debug_Extensions", "Win32_System_SystemInformation", "Win32_System_SystemServices" ] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+bitflags = "2.4"
+anyhow = { version = "1.0" }
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_System", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_Debug_Extensions", "Win32_System_SystemInformation", "Win32_System_SystemServices" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbgeng"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Axel '0vercl0k' Souchet"]
 categories = ["api-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ rust-version = "1.70"
 serde = { version = "1", features = ["derive"], optional = true }
 bitflags = "2.4.2"
 anyhow = { version = "1.0.79" }
-windows = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_Debug_Extensions", "Win32_System_SystemInformation" ] }
+windows = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_Debug_Extensions", "Win32_System_SystemInformation", "Win32_System_SystemServices" ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use windows::core::{ComInterface, IUnknown};
+use windows::core::{IUnknown, Interface};
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
     IDebugControl3, IDebugDataSpaces4, IDebugRegisters, IDebugSymbols3, DEBUG_ADDSYNTHMOD_DEFAULT,
     DEBUG_EXECUTE_DEFAULT, DEBUG_OUTCTL_ALL_CLIENTS, DEBUG_OUTPUT_NORMAL, DEBUG_VALUE,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,9 @@
 pub mod as_pcstr;
 pub mod bits;
 pub mod client;
+
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn DEBUG_EXTENSION_VERSION(major: u32, minor: u32) -> u32 {
+    ((major & 0xffff) << 16) | (minor & 0xffff)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,5 @@ pub mod client;
 #[allow(non_snake_case)]
 #[inline(always)]
 pub fn DEBUG_EXTENSION_VERSION(major: u32, minor: u32) -> u32 {
-    ((major & 0xffff) << 16) | (minor & 0xffff)
+    ((major & 0xff_ff) << 16) | (minor & 0xff_ff)
 }


### PR DESCRIPTION
Found the need for synthetic module support, so I implemented it along with a few other helper methods.
I bumped the windows-rs version, so it might break snapshot if merged. You could just cherry pick the two other commits, if you'd like. 

I'm going to keep using this fork for some of my work unless merged, but would rather contribute it back! Open to feedback, of course. 